### PR TITLE
Art Style Selection Feature for Image Generation

### DIFF
--- a/app/(dashboard)/(routes)/svg/constants.ts
+++ b/app/(dashboard)/(routes)/svg/constants.ts
@@ -7,6 +7,7 @@ export const formSchema = z.object({
   }),
   amount: z.string().min(1),
   resolution: z.string().min(1),
+  styleOptions: z.string().min(1),
 });
 
 export const amountOptions = [
@@ -29,5 +30,24 @@ export const resOptions = [
   {
     value: "1024x1024",
     Label: "1024x1024",
+  },
+];
+
+const metallicPrompt = `a high quality icon of metallic iridescent material, 3D render isometric perspective on a dark background`;
+const watercolorPrompt = `a watercolor-style icon on a dark background, with a soft accent and a dreamy feel`;
+const popPrompt = `a pop art-style icon on a dark background, with bold colors and graphic design elements that pop`;
+
+export const styleOptions = [
+  {
+    value: metallicPrompt,
+    label: "metallic",
+  },
+  {
+    value: popPrompt,
+    label: "pop",
+  },
+  {
+    value: watercolorPrompt,
+    label: "watercolor",
   },
 ];

--- a/app/(dashboard)/(routes)/svg/page.tsx
+++ b/app/(dashboard)/(routes)/svg/page.tsx
@@ -22,7 +22,12 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Form, FormControl, FormField, FormItem } from "@/components/ui/form";
 import { cn } from "@/lib/utils";
 
-import { amountOptions, formSchema, resOptions } from "./constants";
+import {
+  amountOptions,
+  formSchema,
+  resOptions,
+  styleOptions,
+} from "./constants";
 
 import { Empty } from "@/components/ui/Empty";
 import { Loader } from "@/components/ui/loader";
@@ -48,6 +53,7 @@ const ImagePage = () => {
       prompt: "",
       amount: "1",
       resolution: "512x512",
+      styleOptions: styleOptions[2].value,
     },
   });
 
@@ -58,13 +64,12 @@ const ImagePage = () => {
       setImages([]);
 
       const response = await axios.post("/api/svg", values);
-      // console.log('FULL RE:', response)
+
       const urls = response.data;
       setImages(urls);
       console.log(urls);
       form.reset();
     } catch (error: any) {
-      // TODO: Open Pro Modal
       console.log(error);
     } finally {
       router.refresh();
@@ -169,6 +174,34 @@ const ImagePage = () => {
                   </FormItem>
                 )}
               />
+              <FormField
+                control={form.control}
+                name="styleOptions"
+                render={({ field }) => (
+                  <FormItem className="col-span-12 lg:col-span-6">
+                    <Select
+                      disabled={isLoading}
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      defaultValue={field.value}
+                    >
+                      <FormControl className="m-0 p-2">
+                        <SelectTrigger>
+                          <SelectValue defaultValue={field.value} />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {styleOptions.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormItem>
+                )}
+              />
+
               <Button
                 className="col-span-12 lg:col-span-2 w-full"
                 type="submit"


### PR DESCRIPTION
### Description
This pull request introduces a new feature that enhances the current image generation capabilities by allowing users to select an art style for the images they generate. By integrating a selection tool in the UI, users can choose from predefined art styles such as Pop, Metallic, and Watercolor, which will be applied to images generated via the DALL-E API.

### Goals
- **Art Style Selection**: Implement a dropdown menu or a set of selectable icons in the UI, allowing users to choose from different art styles (Pop, Metallic, Watercolor) for image generation.
- **API Integration**: Modify DALL-E API requests to include the selected art style as part of the image generation parameters, ensuring the output aligns with the chosen style.
- **User Interface Enhancements**: Update the user interface to incorporate the new selection tool, ensuring the design remains clean and user-friendly.

### User Story
_As a user, I want to be able to select an art style for the images I generate so that I can tailor the visual output to better align with my preferences or project needs._
